### PR TITLE
Let @decorator pass the function as the first element of *args

### DIFF
--- a/src/decorator.py
+++ b/src/decorator.py
@@ -255,7 +255,10 @@ def decorator(caller, _func=None):
             name = caller.__name__
         callerfunc = caller
         doc = caller.__doc__
-        fun = getfullargspec(callerfunc).args[0]  # first arg
+        # this name is arbitrary.  We don't use the first arg of the
+        # argspec so that we support functions with no named positional arguments
+        # - so the function can be positional-only.
+        fun = 'decorated_function'  # first arg
     else:  # assume caller is an object with a __call__ method
         name = caller.__class__.__name__.lower()
         callerfunc = caller.__call__.__func__

--- a/src/tests/test.py
+++ b/src/tests/test.py
@@ -79,6 +79,22 @@ class ExtraTestCase(unittest.TestCase):
         self.assertNotEqual(f1.__code__.co_filename, f2.__code__.co_filename)
         self.assertNotEqual(f1_orig.__code__.co_filename, f1.__code__.co_filename)
 
+    def test_positional_only_function(self):
+        @decorator
+        def plus5(*args, **kwargs):
+            # this pattern is useful so that any variable name can be used as a keyword
+            # whereas the usual pattern (def ...(f, *args, **kwargs)) makes "f" off limits
+            f = args[0]
+            args = args[1:]
+            return f(*args, **kwargs) + 5
+
+        @plus5
+        def f(*args, **kwargs):
+            return sum(args) + sum(kwargs.values())
+
+        self.assertEqual(f(1,2,3), 11)
+        self.assertEqual(f(a=1, f=2, decorated_function=5), 13)
+
 # ################### test dispatch_on ############################# #
 # adapted from test_functools in Python 3.5
 singledispatch = dispatch_on('obj')

--- a/src/tests/test.py
+++ b/src/tests/test.py
@@ -93,6 +93,9 @@ class ExtraTestCase(unittest.TestCase):
             return sum(args) + sum(kwargs.values())
 
         self.assertEqual(f(1,2,3), 11)
+
+        # test that a keyword arg of decorated_function doesn't conflict with
+        # anything - since that name is used internally
         self.assertEqual(f(a=1, f=2, decorated_function=5), 13)
 
 # ################### test dispatch_on ############################# #


### PR DESCRIPTION
The usual pattern of

```
@decorator
def foo(f, *args, **kwargs):
  ...

@foo
def bar(...):
  ...
```

Has the problem that if we ever get the idea to pass an argument named `f` to `bar`, we cannot pass it as a keyword param because when `foo` is called, it'll get two values for `f` - one passed positionally, and another passed as the keyword.  With this change, we can avoid this problem by writing instead

```
@decorator
def foo(*args, **kwargs):
  f = args[0]
  args = args[1:]
  ...
```

It's unfortunately a little ugly, but nonetheless useful.