### PR TITLE
Enable pylint to support decorator.contextmanager

### DIFF
--- a/src/decorator.py
+++ b/src/decorator.py
@@ -298,7 +298,12 @@ elif n_args == 4:  # (self, gen, args, kwds) Python 3.5
         return _GeneratorContextManager.__init__(self, g, a, k)
     ContextManager.__init__ = __init__
 
-contextmanager = decorator(ContextManager)
+_contextmanager = decorator(ContextManager)
+
+
+def contextmanager(func):
+    # Enable Pylint config: contextmanager-decorators=decorator.contextmanager
+    return _contextmanager(func)
 
 
 # ############################ dispatch_on ############################ #


### PR DESCRIPTION
Using decorator.contextmanager triggers the pylint error E1129 (not-context-manager).

Pylint has a configuration option for this:

    # List of decorators that produce context managers, such as
    # contextlib.contextmanager. Add to this list to register other decorators that
    # produce valid context managers.
    contextmanager-decorators=contextlib.contextmanager,decorator.contextmanager

But the current implementation of decorator.contextmanager prevents this from working.

Changing contextmanager to be a simple function fixes the issue.