### PR TITLE
Adds python3.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,18 @@ sudo: false
 
 language: python
 
-python:
- - "2.6"
- - "2.7"
- - "3.2"
- - "3.3"
- - "3.4"
- - "3.5"
- - "3.6"
+matrix:
+  include:
+    - python: 2.6
+    - python: 2.7
+    - python: 3.2
+    - python: 3.3
+    - python: 3.4
+    - python: 3.5
+    - python: 3.6
+    - python: 3.7
+      dist: xenial
+      sudo: true
 
 install:
   - python setup.py install

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ Decorator module
 
 :Author: Michele Simionato
 :E-mail: michele.simionato@gmail.com
-:Requires: Python from 2.6 to 3.6
+:Requires: Python from 2.6 to 3.7
 :Download page: http://pypi.python.org/pypi/decorator
 :Installation: ``pip install decorator``
 :License: BSD license
@@ -65,7 +65,7 @@ operations:
 .. code-block:: python
 
    from decorator import decorator
-   
+
    @decorator
    def warn_slow(func, timelimit=60, *args, **kw):
        t0 = time.time()
@@ -76,11 +76,11 @@ operations:
        else:
            logging.info('%s took %d seconds', func.__name__, dt)
        return result
-   
+
    @warn_slow  # warn if it takes more than 1 minute
    def preprocess_input_files(inputdir, tempdir):
        ...
-   
+
    @warn_slow(timelimit=600)  # warn if it takes more than 10 minutes
    def run_calculation(tempdir, outdir):
        ...


### PR DESCRIPTION
I have included the test option for `python: 3.7`
I have used the recommended way from the `travis` docs.

The reason why we can not just install `3.7` the same way as `3.6` is described here: https://docs.travis-ci.com/user/languages/python/#development-releases-support

> Recent Python branches require OpenSSL 1.0.2+. As this library is not available for Trusty, 3.7, 3.7-dev, 3.8-dev, and nightly do not work (or use outdated archive).