### PR TITLE
BUG: Allow an argument

### DIFF
--- a/src/decorator.py
+++ b/src/decorator.py
@@ -69,7 +69,7 @@ try:
     from inspect import isgeneratorfunction
 except ImportError:
     # assume no generator function in old Python versions
-    def isgeneratorfunction():
+    def isgeneratorfunction(caller):
         return False
 
 


### PR DESCRIPTION
Just a minor fix to allow the fake `isgeneratorfunction` to take a single argument like the actual `isgeneratorfunction`. Error found by `lgtm.com` analysis on another repo (that vendored `decorator.py`).