### PR TITLE
docs: Create ba decorator

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -709,11 +709,13 @@ In Python 3.2, ``GeneratorContextManager`` objects were enhanced with
 a ``__call__`` method, so that they can be used as decorators, like so:
 
 ```python
->>> @ba 
+>>> ba = before_after('BEFORE', 'AFTER')
+>>>
+>>> @ba
 ... def hello():
 ...     print('hello')
 ...
->>> hello() 
+>>> hello()
 BEFORE
 hello
 AFTER

--- a/src/tests/documentation.py
+++ b/src/tests/documentation.py
@@ -547,6 +547,8 @@ In Python 3.2, ``GeneratorContextManager`` objects were enhanced with
 a ``__call__`` method, so that they can be used as decorators, like so:
 
 ```python
+>>> ba = before_after('BEFORE', 'AFTER')
+>>>
 >>> @ba # doctest: +SKIP
 ... def hello():
 ...     print('hello')


### PR DESCRIPTION
The creation of the "ba" decorator was missing from the docs.