### PR TITLE
Fix for Python 3.10

### DIFF
--- a/src/decorator.py
+++ b/src/decorator.py
@@ -42,7 +42,7 @@ import collections
 
 __version__ = '4.4.1'
 
-if sys.version >= '3':
+if sys.version_info >= (3,):
     from inspect import getfullargspec
 
     def get_init(cls):

--- a/src/tests/documentation.py
+++ b/src/tests/documentation.py
@@ -1421,7 +1421,7 @@ Another attribute copied from the original function is ``__qualname__``,
 the qualified name. This attribute was introduced in Python 3.3.
 """
 
-if sys.version < '3':
+if sys.version_info < (3,):
     function_annotations = ''
 
 today = time.strftime('%Y-%m-%d')
@@ -1654,7 +1654,7 @@ def a_test_for_pylons():
     """
 
 
-if sys.version >= '3':  # tests for signatures specific to Python 3
+if sys.version_info >= (3,):  # tests for signatures specific to Python 3
 
     def test_kwonlydefaults():
         """

--- a/src/tests/test.py
+++ b/src/tests/test.py
@@ -29,7 +29,7 @@ def assertRaises(etype):
         raise Exception('Expected %s' % etype.__name__)
 
 
-if sys.version >= '3.5':
+if sys.version_info >= (3, 5):
     exec('''from asyncio import get_event_loop
 
 @decorator
@@ -92,7 +92,7 @@ class DocumentationTestCase(unittest.TestCase):
 
 class ExtraTestCase(unittest.TestCase):
     def test_qualname(self):
-        if sys.version >= '3.3':
+        if sys.version_info >= (3, 3):
             self.assertEqual(doc.hello.__qualname__, 'hello')
         else:
             with assertRaises(AttributeError):


### PR DESCRIPTION
We don't yet know if 3.10 or 4.0 will follow Python 3.9, but whichever it is, it will probably happen in [2020 when Python 3.9 reaches beta](https://www.python.org/dev/peps/pep-0596/#schedule) and work begins on Python 3.9+1.

There's some code which will return the wrong result for Python 3.10.

It's safer to use `sys.version_info` than `sys.version` to compare the version, rather than assuming the minor number will always be a single-length character.

Found using https://github.com/asottile/flake8-2020.

It also found some code that won't break until Python 10 (!), but we might as well fix those at the same time :)
