### PR TITLE
Don't use strictly larger for warn_slow test

### DIFF
--- a/src/tests/documentation.py
+++ b/src/tests/documentation.py
@@ -1869,7 +1869,7 @@ def warn_slow(func, duration=0, *args, **kwargs):
     t0 = time.time()
     res = func(*args, **kwargs)
     dt = time.time() - t0
-    if dt > duration:
+    if dt >= duration:
         print('%s is slow' % func.__name__)
     return res
 


### PR DESCRIPTION
In certain circumstances the time difference can be 0, which previously
causes the test to fail, e.g. https://github.com/NixOS/nixpkgs/issues/75554