### PR TITLE
Fix python version in setup for release 5.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ if __name__ == '__main__':
           py_modules=['decorator'],
           keywords="decorators generic utility",
           platforms=["All"],
-          python_requires='>=2.6, !=3.0.*, !=3.1.*',
+          python_requires='>=3.5',
           classifiers=['Development Status :: 5 - Production/Stable',
                        'Intended Audience :: Developers',
                        'License :: OSI Approved :: BSD License',


### PR DESCRIPTION
The PR adjust the python_requires parameter in setup to prevent incompatible installation.

fix #99