### PR TITLE
Cythonization support

### DIFF
--- a/src/decorator.py
+++ b/src/decorator.py
@@ -71,7 +71,7 @@ class FunctionMaker(object):
                 self.name = '_lambda_'
             self.doc = func.__doc__
             self.module = func.__module__
-            if inspect.isfunction(func):
+            if inspect.isroutine(func):
                 argspec = getfullargspec(func)
                 self.annotations = getattr(func, '__annotations__', {})
                 for a in ('args', 'varargs', 'varkw', 'defaults', 'kwonlyargs',


### PR DESCRIPTION
Hi Mike,

decorator-decorated methods can't be cythonized because cyfunctions are evaluated to False with `inspect.isfunction()`. However, necessary inspection elements for decorator-decoration can be carried out okay as long as `inspect.isroutine()` is evaluated to True.
So I would like to suggest to replace the test in the `FunctionMaker` to use `inspect.isroutine()`. I tested cythonizing a fairly complex proprietary ipython magic class, and it works well.

 