### PR TITLE
Docs: Replace deprecated logging.warn with logging.warning

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,7 +82,7 @@ operations:
        result = func(*args, **kw)
        dt = time.time() - t0
        if dt > timelimit:
-           logging.warn('%s took %d seconds', func.__name__, dt)
+           logging.warning('%s took %d seconds', func.__name__, dt)
        else:
            logging.info('%s took %d seconds', func.__name__, dt)
        return result


### PR DESCRIPTION

Replace `logging.warn` (deprecated in [Python 2.7, 2011](https://github.com/python/cpython/commit/04d5bc00a219860c69ea17eaa633d3ab9917409f)) with `logging.warning` (added in [Python 2.3, 2003](https://github.com/python/cpython/commit/6fa635df7aa88ae9fd8b41ae42743341316c90f7)).

* https://docs.python.org/3/library/logging.html#logging.Logger.warning
* https://github.com/python/cpython/issues/57444
