### PR TITLE
Add support for Python 3.11

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,7 +32,7 @@ lacking dunder attributes, like `dict.__setitem__`.
 ## 5.0.7 (2021-04-14)
 
 The decorator module was not passing correctly the defaults inside the
-`*args` tuple, thanks to Dan Shult for the fix. Also fixed some mispellings
+`*args` tuple, thanks to Dan Shult for the fix. Also fixed some misspellings
 in the documentation and integrated codespell in the CI, thanks to 
 Christian Clauss.
 

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -4,7 +4,7 @@
 |---|---|
 |E-mail | michele.simionato@gmail.com|
 |Version| 5.1.1 (2022-01-07)|
-|Supports| Python 3.5, 3.6, 3.7, 3.8, 3.9, 3.10|
+|Supports| Python 3.5, 3.6, 3.7, 3.8, 3.9, 3.10, 3.11|
 |Download page| http://pypi.python.org/pypi/decorator/5.1.1|
 |Installation| ``pip install decorator``|
 |License | BSD license|

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -5,7 +5,7 @@
 |E-mail | michele.simionato@gmail.com|
 |Version| 5.1.1 (2022-01-07)|
 |Supports| Python 3.5, 3.6, 3.7, 3.8, 3.9, 3.10, 3.11|
-|Download page| http://pypi.python.org/pypi/decorator/5.1.1|
+|Download page| https://pypi.org/project/decorator/5.1.1|
 |Installation| ``pip install decorator``|
 |License | BSD license|
 

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -1492,7 +1492,7 @@ with ``functools.singledispatch``, the assertion will break: ``g`` will return
 will insert the ``Container`` class right before ``S``.
 
 Notice that here I am not making any bold claim such as "the standard
-library algorithm is wrong and my algorithm is right" or viceversa. It
+library algorithm is wrong and my algorithm is right" or vice versa. It
 just point out that there are some subtle differences. The only way to
 understand what is really happening here is to scratch your head by
 looking at the implementations. I will just notice that

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ if __name__ == '__main__':
                        'Programming Language :: Python :: 3.8',
                        'Programming Language :: Python :: 3.9',
                        'Programming Language :: Python :: 3.10',
+                       'Programming Language :: Python :: 3.11',
                        'Programming Language :: Python :: Implementation :: CPython',
                        'Topic :: Software Development :: Libraries',
                        'Topic :: Utilities'],

--- a/src/tests/documentation.py
+++ b/src/tests/documentation.py
@@ -14,7 +14,7 @@ doc = r"""# Decorators for Humans
 |---|---|
 |E-mail | michele.simionato@gmail.com|
 |Version| $VERSION ($DATE)|
-|Supports| Python 3.5, 3.6, 3.7, 3.8, 3.9, 3.10|
+|Supports| Python 3.5, 3.6, 3.7, 3.8, 3.9, 3.10, 3.11|
 |Download page| http://pypi.python.org/pypi/decorator/$VERSION|
 |Installation| ``pip install decorator``|
 |License | BSD license|

--- a/src/tests/documentation.py
+++ b/src/tests/documentation.py
@@ -15,7 +15,7 @@ doc = r"""# Decorators for Humans
 |E-mail | michele.simionato@gmail.com|
 |Version| $VERSION ($DATE)|
 |Supports| Python 3.5, 3.6, 3.7, 3.8, 3.9, 3.10, 3.11|
-|Download page| http://pypi.python.org/pypi/decorator/$VERSION|
+|Download page| https://pypi.org/project/decorator/$VERSION|
 |Installation| ``pip install decorator``|
 |License | BSD license|
 

--- a/src/tests/documentation.py
+++ b/src/tests/documentation.py
@@ -1171,7 +1171,7 @@ with ``functools.singledispatch``, the assertion will break: ``g`` will return
 will insert the ``Container`` class right before ``S``.
 
 Notice that here I am not making any bold claim such as "the standard
-library algorithm is wrong and my algorithm is right" or viceversa. It
+library algorithm is wrong and my algorithm is right" or vice versa. It
 just point out that there are some subtle differences. The only way to
 understand what is really happening here is to scratch your head by
 looking at the implementations. I will just notice that


### PR DESCRIPTION
Python 3.11 was [released on 2022-10-24](https://discuss.python.org/t/python-3-11-0-final-is-now-available/20291?u=hugovk) 🚀 

[![image](https://user-images.githubusercontent.com/1324225/198233993-5b79523b-370f-4316-a4be-9403c8209068.png)](https://discuss.python.org/t/python-3-11-0-final-is-now-available/20291?u=hugovk)

Also update download links and fix codespell errors.