### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,15 +14,17 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v3

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -4,7 +4,7 @@
 |---|---|
 |E-mail | michele.simionato@gmail.com|
 |Version| 5.1.1 (2022-01-07)|
-|Supports| Python 3.5, 3.6, 3.7, 3.8, 3.9, 3.10, 3.11|
+|Supports| Python 3.5, 3.6, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12|
 |Download page| https://pypi.org/project/decorator/5.1.1|
 |Installation| ``pip install decorator``|
 |License | BSD license|

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ if __name__ == '__main__':
                        'Programming Language :: Python :: 3.9',
                        'Programming Language :: Python :: 3.10',
                        'Programming Language :: Python :: 3.11',
+                       'Programming Language :: Python :: 3.12',
                        'Programming Language :: Python :: Implementation :: CPython',
                        'Topic :: Software Development :: Libraries',
                        'Topic :: Utilities'],

--- a/src/tests/documentation.py
+++ b/src/tests/documentation.py
@@ -14,7 +14,7 @@ doc = r"""# Decorators for Humans
 |---|---|
 |E-mail | michele.simionato@gmail.com|
 |Version| $VERSION ($DATE)|
-|Supports| Python 3.5, 3.6, 3.7, 3.8, 3.9, 3.10, 3.11|
+|Supports| Python 3.5, 3.6, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12|
 |Download page| https://pypi.org/project/decorator/$VERSION|
 |Installation| ``pip install decorator``|
 |License | BSD license|


### PR DESCRIPTION
The [Python 3.12 release candidate is out!](https://discuss.python.org/t/python-3-12-0-release-candidate-1-released/31137?u=hugovk) :rocket:

> ## Call to action
> 
> We strongly encourage maintainers of third-party Python projects to prepare their projects for 3.12 compatibilities during this phase, and where necessary publish Python 3.12 wheels on PyPI to be ready for the final release of 3.12.0.