### PR TITLE
Use SPDX license identifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ if __name__ == '__main__':
           author='Michele Simionato',
           author_email='michele.simionato@gmail.com',
           url='https://github.com/micheles/decorator',
-          license="new BSD License",
+          license="BSD-2-Clause",
           package_dir={'': 'src'},
           py_modules=['decorator'],
           keywords="decorators generic utility",


### PR DESCRIPTION
For automatic dependency scanners the SPDX ID is better since it is unambiguous. "new BSD License" could mean a lot looking at all the BSD licenses: https://spdx.org/licenses/