### PR TITLE
drop python<=3.7 support

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 #
 # decorator documentation build configuration file, created by
 # sphinx-quickstart on Sun Jul 23 17:11:44 2017.

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ if __name__ == '__main__':
                        'Natural Language :: English',
                        'Operating System :: OS Independent',
                        'Programming Language :: Python',
-                       'Programming Language :: Python :: 3.7',
                        'Programming Language :: Python :: 3.8',
                        'Programming Language :: Python :: 3.9',
                        'Programming Language :: Python :: 3.10',

--- a/src/decorator.py
+++ b/src/decorator.py
@@ -48,7 +48,7 @@ EMPTY = inspect.Parameter.empty
 
 
 # this is not used anymore in the core, but kept for backward compatibility
-class FunctionMaker(object):
+class FunctionMaker:
     """
     An object with the ability to create functions with a given signature.
     It has attributes name, doc, module, signature, defaults, dict and
@@ -88,7 +88,7 @@ class FunctionMaker(object):
                     allargs.append('*')  # single star syntax
                 for a in self.kwonlyargs:
                     allargs.append('%s=None' % a)
-                    allshortargs.append('%s=%s' % (a, a))
+                    allshortargs.append('{}={}'.format(a, a))
                 if self.varkw:
                     allargs.append('**' + self.varkw)
                     allshortargs.append('**' + self.varkw)
@@ -146,7 +146,7 @@ class FunctionMaker(object):
                               self.shortsignature.split(',')])
         for n in names:
             if n in ('_func_', '_call_'):
-                raise NameError('%s is overridden in\n%s' % (n, src))
+                raise NameError('{} is overridden in\n{}'.format(n, src))
 
         if not src.endswith('\n'):  # add a newline for old Pythons
             src += '\n'
@@ -223,8 +223,7 @@ def decorate(func, caller, extras=(), kwsyntax=False):
         def fun(*args, **kw):
             if not kwsyntax:
                 args, kw = fix(args, kw, sig)
-            for res in caller(func, *(extras + args), **kw):
-                yield res
+            yield from caller(func, *(extras + args), **kw)
     else:
         def fun(*args, **kw):
             if not kwsyntax:
@@ -392,7 +391,7 @@ def dispatch_on(*dispatch_args):
                 n_vas = len(vas)
                 if n_vas > 1:
                     raise RuntimeError(
-                        'Ambiguous dispatch for %s: %s' % (t, vas))
+                        'Ambiguous dispatch for {}: {}'.format(t, vas))
                 elif n_vas == 1:
                     va, = vas
                     mro = type('t', (t, va), {}).mro()[1:]

--- a/src/tests/documentation.py
+++ b/src/tests/documentation.py
@@ -1390,8 +1390,8 @@ def decorator_apply(dec, func):
 
 
 def _trace(f, *args, **kw):
-    kwstr = ', '.join('%r: %r' % (k, kw[k]) for k in sorted(kw))
-    print("calling %s with args %s, {%s}" % (f.__name__, args, kwstr))
+    kwstr = ', '.join('{!r}: {!r}'.format(k, kw[k]) for k in sorted(kw))
+    print("calling {} with args {}, {{{}}}".format(f.__name__, args, kwstr))
     return f(*args, **kw)
 
 
@@ -1409,11 +1409,11 @@ class Future(threading.Thread):
             counter = func.counter
         except AttributeError:  # instantiate the counter at the first call
             counter = func.counter = itertools.count(1)
-        name = '%s-%s' % (func.__name__, next(counter))
+        name = '{}-{}'.format(func.__name__, next(counter))
 
         def func_wrapper():
             self._result = func(*args, **kw)
-        super(Future, self).__init__(target=func_wrapper, name=name)
+        super().__init__(target=func_wrapper, name=name)
         self.start()
 
     def result(self):
@@ -1489,7 +1489,7 @@ def blocking(f, msg='blocking', *args, **kw):
         return f.result
 
 
-class User(object):
+class User:
     "Will just be able to see a page"
 
 
@@ -1525,7 +1525,7 @@ def restricted(func, user_class=User, *args, **kw):
             % (self.user, func.__name__))
 
 
-class Action(object):
+class Action:
     @restricted(user_class=User)
     def view(self):
         "Any user can view objects"
@@ -1539,7 +1539,7 @@ class Action(object):
         "Only the admin can delete objects"
 
 
-class TailRecursive(object):
+class TailRecursive:
     """
     tail_recursive decorator based on Kay Schluehr's recipe
     http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/496691
@@ -1648,7 +1648,7 @@ def test_kwonly_star_notation():
 # #######################  multiple dispatch ############################ #
 
 
-class XMLWriter(object):
+class XMLWriter:
     def __init__(self, **config):
         self.cfg = config
 
@@ -1662,15 +1662,15 @@ def writefloat(self, obj):
     return '<float>%s</float>' % obj
 
 
-class Rock(object):
+class Rock:
     ordinal = 0
 
 
-class Paper(object):
+class Paper:
     ordinal = 1
 
 
-class Scissors(object):
+class Scissors:
     ordinal = 2
 
 
@@ -1707,7 +1707,7 @@ def winStrongRockPaper(a, b):
     return 0
 
 
-class WithLength(object):
+class WithLength:
     def __len__(self):
         return 0
 
@@ -1734,7 +1734,7 @@ def get_length_set(obj):
     return 1
 
 
-class C(object):
+class C:
     "Registered as Sized and Iterable"
 
 
@@ -1764,7 +1764,7 @@ def singledispatch_example2():
     # adapted from functools.singledispatch test case
     singledispatch = dispatch_on('arg')
 
-    class S(object):
+    class S:
         pass
 
     class V(c.Sized, S):
@@ -1856,7 +1856,7 @@ def to_method(f):
     self = inspect.Parameter('self', inspect.Parameter.POSITIONAL_OR_KEYWORD)
     params.insert(0, self)  # insert self
     del params[-1]  # remove context
-    newsig = '%s%s' % (f.__name__, sig.replace(parameters=params))
+    newsig = '{}{}'.format(f.__name__, sig.replace(parameters=params))
     return FunctionMaker.create(
         newsig, 'context = self.context; return _func_%s' % sig,
         dict(_func_=f))

--- a/src/tests/test.py
+++ b/src/tests/test.py
@@ -218,7 +218,7 @@ class TestSingleDispatch(unittest.TestCase):
         def g(obj):
             return "base"
 
-        class A(object):
+        class A:
             pass
 
         class C(A):
@@ -250,7 +250,7 @@ class TestSingleDispatch(unittest.TestCase):
 
         @g.register(int)
         def g_int(i):
-            return "int %s" % (i,)
+            return "int {}".format(i)
         self.assertEqual(g(""), "base")
         self.assertEqual(g(12), "int 12")
 
@@ -296,7 +296,7 @@ class TestSingleDispatch(unittest.TestCase):
     def test_register_abc(self):
         d = {"a": "b"}
         l = [1, 2, 3]
-        s = set([object(), None])
+        s = {object(), None}
         f = frozenset(s)
         t = (1, 2, 3)
 
@@ -425,7 +425,7 @@ class TestSingleDispatch(unittest.TestCase):
         c.Set.register(O)
         self.assertEqual(g(o), "set")
 
-        class P(object):
+        class P:
             pass
         p = P()
         self.assertEqual(g(p), "base")
@@ -463,7 +463,7 @@ class TestSingleDispatch(unittest.TestCase):
         # MutableMapping's bases implicit as well from defaultdict's
         # perspective.
         with assertRaises(RuntimeError):
-            self.assertEqual(h(defaultdict(lambda: 0)), "sized")
+            self.assertEqual(h(defaultdict(int)), "sized")
 
         class R(defaultdict):
             pass
@@ -484,7 +484,7 @@ class TestSingleDispatch(unittest.TestCase):
         with assertRaises(RuntimeError):  # was no error
             self.assertEqual(i(r), "sequence")
 
-        class S(object):
+        class S:
             pass
 
         class T(S, c.Sized):
@@ -495,7 +495,7 @@ class TestSingleDispatch(unittest.TestCase):
         c.Container.register(T)
         self.assertEqual(h(t), "sized")   # because it's explicitly in the MRO
 
-        class U(object):
+        class U:
             def __len__(self):
                 return 0
         u = U()


### PR DESCRIPTION
According to https://endoflife.date/python python 3.7 has been EOSed in 27 Jun 2023.
Pass all code over `pyupgrade --py3.8`.