### PR TITLE
Fix test.py path in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Testing
 
 If you have the source code installation you can run the tests with
 
- `$ python src/tests/test.py -v`
+ `$ python tests/test.py -v`
 
 or (if you have setuptools installed)
 


### PR DESCRIPTION
The `test.py` file is in the `tests` folder instead of `src/tests`.