### PR TITLE
Set type-consistent initial values for args,varargs,varkw,defaults,kwonlyargs,kwonlydefaults in FunctionMaker

### DIFF
--- a/src/decorator.py
+++ b/src/decorator.py
@@ -60,7 +60,10 @@ class FunctionMaker(object):
     _compile_count = itertools.count()
 
     # make pylint happy
-    args = varargs = varkw = defaults = kwonlyargs = kwonlydefaults = ()
+    args = []
+    varargs =  varkw = defaults = None
+    kwonlyargs = []
+    kwonlydefaults = {}
 
     def __init__(self, func=None, name=None, signature=None,
                  defaults=None, doc=None, module=None, funcdict=None):

--- a/src/decorator.py
+++ b/src/decorator.py
@@ -61,7 +61,7 @@ class FunctionMaker(object):
 
     # make pylint happy
     args = []
-    varargs =  varkw = defaults = None
+    varargs = varkw = defaults = None
     kwonlyargs = []
     kwonlydefaults = {}
 


### PR DESCRIPTION
I noticed this while exploring https://github.com/micheles/decorator/issues/173

The initial value for args,vargs,varkw,defaults,kwonlyargs,kwonlydefaults is currently an empty tuple, which then gets overwritten with a different type. But, empty tuple doesn't match the type that ends up being assigned, for example:
- `args` gets initialised as `()`
- but then, it gets assigned a `list[str]`

The [inspect.getfullargspec](https://docs.python.org/3/library/inspect.html#inspect.getfullargspec) docs document:

- args is a list of the positional parameter names.
- varargs is the name of the * parameter or None if arbitrary positional arguments are not accepted.
- varkw is the name of the ** parameter or None if arbitrary keyword arguments are not accepted.
- defaults is an n-tuple of default argument values corresponding to the last n positional parameters, or None if there are no such defaults defined.
- kwonlyargs is a list of keyword-only parameter names in declaration order.
- kwonlydefaults is a dictionary mapping parameter names from kwonlyargs to the default values used if no argument is supplied

So, I'm suggesting that type-appropriate initial values be set

Then, when `stubtest` will be run, it won't show errors such as
```
error: decorator.FunctionMaker.args variable differs from runtime type tuple[()]
Stub: in file /home/marcogorelli/decorator-dev/src/decorator-stubs/__init__.pyi:20
builtins.list[builtins.str]
Runtime:
()
```