### PR TITLE
Inline stubs from typeshed

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -33,3 +33,26 @@ jobs:
     - run: codespell --ignore-words-list="assertIn,ba,claus,vas" --quiet-level=2
     - run: flake8 . --count --ignore=E122,E226,E265,E741,E742 --max-complexity=22 --max-line-length=124 --show-source --statistics
     - run: python tests/test.py -v
+
+  stubtest:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.x
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.x
+        allow-prereleases: true
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install mypy
+        python -m pip install -e .
+    - run: |
+        python -m mypy.stubtest decorator
+        python -m mypy src/decorator.py
+

--- a/src/decorator-stubs/__init__.pyi
+++ b/src/decorator-stubs/__init__.pyi
@@ -1,0 +1,73 @@
+import inspect
+from builtins import dict as _dict  # alias to avoid conflicts with attribute name
+from collections.abc import Callable, Generator, Iterator
+from contextlib import _GeneratorContextManager
+from inspect import Signature, getfullargspec as getfullargspec, iscoroutinefunction as iscoroutinefunction
+from re import Pattern
+from typing import Any, Final, Literal, TypeVar
+from typing_extensions import ParamSpec
+
+_C = TypeVar("_C", bound=Callable[..., Any])
+_Func = TypeVar("_Func", bound=Callable[..., Any])
+_T = TypeVar("_T")
+_P = ParamSpec("_P")
+
+DEF: Final[Pattern[str]]
+POS: Final[Literal[inspect._ParameterKind.POSITIONAL_OR_KEYWORD]]
+EMPTY: Final[type[inspect._empty]]
+
+class FunctionMaker:
+    args: list[str]
+    varargs: str | None
+    varkw: str | None
+    defaults: tuple[Any, ...] | None
+    kwonlyargs: list[str]
+    kwonlydefaults: dict[str, Any] | None
+    shortsignature: str | None
+    name: str
+    doc: str | None
+    module: str | None
+    annotations: _dict[str, Any]
+    signature: str
+    dict: _dict[str, Any]
+    def __init__(
+        self,
+        func: Callable[..., Any] | None = ...,
+        name: str | None = ...,
+        signature: str | None = ...,
+        defaults: tuple[Any, ...] | None = ...,
+        doc: str | None = ...,
+        module: str | None = ...,
+        funcdict: _dict[str, Any] | None = ...,
+    ) -> None: ...
+    def update(self, func: Any, **kw: Any) -> None: ...
+    def make(
+        self, src_templ: str, evaldict: _dict[str, Any] | None = ..., addsource: bool = ..., **attrs: Any
+    ) -> Callable[..., Any]: ...
+    @classmethod
+    def create(
+        cls,
+        obj: Any,
+        body: str,
+        evaldict: _dict[str, Any],
+        defaults: tuple[Any, ...] | None = ...,
+        doc: str | None = ...,
+        module: str | None = ...,
+        addsource: bool = ...,
+        **attrs: Any,
+    ) -> Callable[..., Any]: ...
+
+def fix(args: tuple[Any, ...], kwargs: dict[str, Any], sig: Signature) -> tuple[tuple[Any, ...], dict[str, Any]]: ...
+def decorate(func: _Func, caller: Callable[..., Any], extras: tuple[Any, ...] = ..., kwsyntax: bool = False) -> _Func: ...
+def decoratorx(caller: Callable[..., Any]) -> Callable[..., Any]: ...
+def decorator(
+    caller: Callable[..., Any], _func: Callable[..., Any] | None = None, kwsyntax: bool = False
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]: ...
+
+class ContextManager(_GeneratorContextManager[_T]):
+    def __init__(self, g: Callable[..., Generator[_T]], *a: Any, **k: Any) -> None: ...
+    def __call__(self, func: _C) -> _C: ...
+
+def contextmanager(func: Callable[_P, Iterator[_T]]) -> Callable[_P, ContextManager[_T]]: ...
+def append(a: type, vancestors: list[type]) -> None: ...
+def dispatch_on(*dispatch_args: Any) -> Callable[[Callable[..., Any]], Callable[..., Any]]: ...

--- a/src/decorator.py
+++ b/src/decorator.py
@@ -40,6 +40,7 @@ import itertools
 import functools
 from contextlib import _GeneratorContextManager
 from inspect import getfullargspec, iscoroutinefunction, isgeneratorfunction
+from typing import Any, Dict, List, Optional
 
 __version__ = '5.2.0'
 
@@ -60,10 +61,10 @@ class FunctionMaker(object):
     _compile_count = itertools.count()
 
     # make pylint happy
-    args = []
+    args: List[str] = []
     varargs = varkw = defaults = None
-    kwonlyargs = []
-    kwonlydefaults = {}
+    kwonlyargs: List[str] = []
+    kwonlydefaults: Optional[Dict[str, Any]] = None
 
     def __init__(self, func=None, name=None, signature=None,
                  defaults=None, doc=None, module=None, funcdict=None):


### PR DESCRIPTION
closes https://github.com/micheles/decorator/issues/173

I tried this out, and doing a git install from my branch with the snippet in https://github.com/micheles/decorator/issues/173#issuecomment-2975790178 reveals:
```console
(scratch) marcogorelli@DESKTOP-U8OKFP3:~/scratch$ uv pip install git+https://github.com/MarcoGorelli/decorator.git@stubs
    Updated https://github.com/MarcoGorelli/decorator.git (638c91d58c2053e8058b30cbcd331bce7a95a6c8)
Resolved 1 package in 2.91s
      Built decorator @ git+https://github.com/MarcoGorelli/decorator.git@638c91d58c2053e8058b30cbcd331bce7a95a6c8
Prepared 1 package in 1.20s
Installed 1 package in 5ms
 + decorator==5.2.0 (from git+https://github.com/MarcoGorelli/decorator.git@638c91d58c2053e8058b30cbcd331bce7a95a6c8)
(scratch) marcogorelli@DESKTOP-U8OKFP3:~/scratch$ mypy t.py
t.py:6: error: "type[FunctionMaker]" has no attribute "new"  [attr-defined]
Found 1 error in 1 file (checked 1 source file)
```
, without needing to install extra packages or anything else 🥳 