### PR TITLE
Fix FunctionMaker.create() with return type annotation (#138)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@ HISTORY
 
 ## Unreleased
 
+Fixed `FunctionMaker.create` raising a `SyntaxError` when the signature
+string contains a return annotation, e.g.
+`create("f(a) -> int", "return a")` (issue #138).
+
 ## 5.3.1 (2026-05-18)
 
 Added license SPDX identifier to pyproject.toml (reported by

--- a/src/decorator/__init__.py
+++ b/src/decorator/__init__.py
@@ -253,22 +253,28 @@ class FunctionMaker:
         attribute __source__ is added to the result. The attributes attrs
         are added, if any.
         """
-        if isinstance(obj, str):  # "name(signature)"
+        if isinstance(obj, str):  # "name(signature)" or "name(signature) -> ret"
             name, rest = obj.strip().split('(', 1)
-            signature = rest[:-1]  # strip a right parens
+            # split the argument list from an optional return annotation;
+            # the argument list ends at the last right parens
+            signature, _, return_annotation = rest.rpartition(')')
             func = None
         else:  # a function
             name = None
             signature = None
+            return_annotation = ''
             func = obj
         self = cls(func, name, signature, defaults, doc, module)
+        self.return_annotation = return_annotation  # e.g. " -> int"
         ibody = '\n'.join('    ' + line for line in body.splitlines())
         caller = evaldict.get('_call_')  # when called from `decorate`
         if caller and iscoroutinefunction(caller):
-            body = ('async def %(name)s(%(signature)s):\n' + ibody)
+            body = ('async def %(name)s(%(signature)s)'
+                    '%(return_annotation)s:\n' + ibody)
             body = re.sub(r'\breturn\b', 'return await', body)
         else:
-            body = 'def %(name)s(%(signature)s):\n' + ibody
+            body = ('def %(name)s(%(signature)s)'
+                    '%(return_annotation)s:\n' + ibody)
         return self.make(body, evaldict, addsource, **attrs)
 
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -6,7 +6,7 @@ import inspect
 import functools
 import asyncio
 from collections import defaultdict, ChainMap, abc as c
-from decorator import dispatch_on, contextmanager, decorator
+from decorator import dispatch_on, contextmanager, decorator, FunctionMaker
 try:
     from . import documentation as doc  # good with pytest
 except ImportError:
@@ -113,6 +113,23 @@ class ExtraTestCase(unittest.TestCase):
     def test_signature(self):
         sig = inspect.signature(doc.f1)
         self.assertEqual(str(sig), '(x)')
+
+    def test_return_annotation(self):
+        # see https://github.com/micheles/decorator/issues/138
+        def add(a, b):
+            return a + b
+
+        # a signature string without a return annotation still works
+        add2 = FunctionMaker.create(
+            'add2(a: int, b: int)', 'return add(a, b)',
+            evaldict={'add': add})
+        self.assertEqual(add2(6, 8), 14)
+
+        # a signature string with a return annotation must not raise
+        add3 = FunctionMaker.create(
+            'add3(a: int, b: int) -> int', 'return add(a, b)',
+            evaldict={'add': add})
+        self.assertEqual(add3(6, 8), 14)
 
     def test_unique_filenames(self):
         @decorator


### PR DESCRIPTION
## Summary

`FunctionMaker.create()` raised a `SyntaxError` when the signature string contained a return annotation, e.g.:

```python
FunctionMaker.create("add3(a: int, b: int) -> int", "return add(a, b)", evaldict={"add": add})
```

The parser assumed the signature always ended with `)` and stripped the last character with `rest[:-1]`, then unconditionally re-appended `)` when emitting the `def` line. With a return annotation present, this produced invalid source such as:

```python
def add3(a: int, b: int) -> in):
    return add(a, b)
```

which failed to compile. This matches the report in #138 (and the earlier acknowledgement in #114).

## Fix

In `FunctionMaker.create()`, split the argument list from an optional `-> ...` return annotation using `rest.rpartition(')')`, and reattach the annotation after the closing paren when building the `def` line (via a `%(return_annotation)s` placeholder so it is substituted safely). Signatures without a return annotation are handled exactly as before (`rpartition` yields an empty tail), so behavior is unchanged for the existing case.

## Tests / Verification

- Added `ExtraTestCase.test_return_annotation` covering both a signature without an annotation and one with a `-> int` return annotation. It fails on `master` with `SyntaxError: unmatched ')'` and passes with this change.
- Full suite green: `python tests/test.py -v` -> `Ran 26 tests ... OK` (including the doctest suite).
- Lint/type checks clean: `flake8` (CI config), `codespell` (CI config), `python -m mypy.stubtest decorator`, and `python -m mypy src/decorator/__init__.py` all pass.
- Added a `CHANGES.md` entry under "Unreleased".

Disclosure: prepared with AI assistance; reviewed and verified locally.
